### PR TITLE
Fix PermGen OOME

### DIFF
--- a/src/main/java/pl/polidea/robospock/RoboSputnik.java
+++ b/src/main/java/pl/polidea/robospock/RoboSputnik.java
@@ -22,11 +22,16 @@ public class RoboSputnik extends Runner implements Filterable, Sortable {
     // "cannot cast from Sputnik to Sputnik"
     private Runner sputnikRunner;
 
-    public RoboSputnik(final Class<?> clazz) throws InitializationError {
-        final RobolectricClassLoader classLoader = createClassLoader();
+    private static RobolectricClassLoader classLoader;
 
-        // this line prevents overloading class loader ? LOL
-        classLoader.delegateLoadingOf(ArrayUtil.class.getName());
+    public RoboSputnik(final Class<?> clazz) throws InitializationError {
+
+        //Reuse classloader to decrease perm usage and speed up tests
+        if (classLoader == null) {
+            classLoader = createClassLoader();
+            // this line prevents overloading class loader ? LOL
+            classLoader.delegateLoadingOf(ArrayUtil.class.getName());
+        }
 
         final Class<?> delegateClass = classLoader.bootstrap(Sputnik.class);
         try {


### PR DESCRIPTION
_Why I did it?_
When running multiple tests with RoboSpecification, perm size increases drastically.
For ~10 specifications it can cause OutOfMemory errors. 

_How I did it?_
Large perm usage was due to creating separated classloader for every
specification. Create RobolectricClassLoader as static field,
initialize it only once reuse it among RoboSpecifications.
