### PR TITLE
Change version of spock-core and groovy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ out/
 # Android
 local.properties
 
+# Android Studio 1.0.1
+gen/
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.5.0
+version=0.6.0-beta-1
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 11 04:18:32 JST 2014
+#Tue Dec 16 00:59:30 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/robospock/build.gradle
+++ b/robospock/build.gradle
@@ -11,8 +11,8 @@ description = 'RoboSpock testing library'
 sourceCompatibility = 1.6
 
 dependencies {
-    compile "org.codehaus.groovy:groovy-all:1.8.6"
-    compile "org.spockframework:spock-core:0.7-groovy-1.8"
+    compile "org.codehaus.groovy:groovy-all:2.3.8"
+    compile "org.spockframework:spock-core:0.7-groovy-2.0"
 
     // Android part
     //compile "org.roboguice:roboguice:2.0"

--- a/sampleApp/build.gradle
+++ b/sampleApp/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 apply plugin: 'com.android.application'
@@ -24,7 +24,6 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
Hi,
Since groovy 2.4 (current 2.4.0-beta-4) we are able to write Android apps in groovy. However robospock in current 0.5.0 is not compatible with groovy 2.4 due to obsolete version of spock-core used. It causes some problems in testing (ex. generated equals method by @Cannonical breaks tests).

To solve this problem I have changed versions of groovy and spock to newest release version (2.3.8 and 0.7-groovy-2.0). This changes will NOT be backwards compatible with robospock 0.5.0 so I have also changed version to 0.6.0-beta-1.
Other changes are recommended by new Android Studio v1.0.1

It is my first pull request ever and so I don't know how to suggest that my pull request should be merged to new branch.
Karol Kowalski - OrdonTeam
