### PR TITLE
Read AndroidManifest from new location.

### DIFF
--- a/robospock/src/main/java/org/robospock/internal/GradleRoboSputnik.java
+++ b/robospock/src/main/java/org/robospock/internal/GradleRoboSputnik.java
@@ -49,7 +49,13 @@ public class GradleRoboSputnik extends RoboSputnik {
         }
 
         if (FileFsFile.from(BUILD_OUTPUT, "manifests").exists()) {
-            manifest = FileFsFile.from(BUILD_OUTPUT, "manifests", "full", flavor, type, "AndroidManifest.xml");
+            if(FileFsFile.from(BUILD_OUTPUT, "manifests", "full").exists()){
+                // pre Android Gradle 2.2
+                manifest = FileFsFile.from(BUILD_OUTPUT, "manifests", "full", flavor, type, "AndroidManifest.xml");
+            } else {
+                // Android Gradle 2.2.+
+                manifest = FileFsFile.from(BUILD_OUTPUT, "manifests", "aapt", flavor, type, "AndroidManifest.xml");
+            }
         } else {
             manifest = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "AndroidManifest.xml");
         }


### PR DESCRIPTION
Android Gradle plugin 2.2.+ has moved where manifest is built. Adding some lines to be compatible with old and new plugins.
